### PR TITLE
change readnetcdf2 function for glaciers

### DIFF
--- a/cwatm/management_modules/data_handling.py
+++ b/cwatm/management_modules/data_handling.py
@@ -1143,6 +1143,11 @@ def readnetcdf2(namebinding, date, useDaily='daily', value='None', addZeros = Fa
            mapnp = np.flipud(mapnp)
     except:
        ii = 1
+    if 'Glacier' in namebinding:
+        cutcheckmask = maskinfo['shape'][0] * maskinfo['shape'][1]
+        cutcheckmap = nf1.variables[value].shape[1] * nf1.variables[value].shape[2]
+        cut = True
+        if cutcheckmask == cutcheckmap: cut = False
 
     if cut:
         if turn_latitude:


### PR DESCRIPTION
glacier input data for a basin simulation can either be given as global data which has to be cut to basin extent or glacier map that equals basin extent and does not need to be cut