### PR TITLE
pySnowClim Init Conditions + Bug Fixes

### DIFF
--- a/cwatm/hydrological_modules/evaporationPot.py
+++ b/cwatm/hydrological_modules/evaporationPot.py
@@ -79,9 +79,9 @@ class evaporationPot(object):
     def vari_pySnowClim(self,Psycon, RNup, RLN, ESat):
         # if pysnowclim vraibles missing are calculated
         if self.var.usepySnowClim:
+            # for pySnowclim
+            eps = 0.621979008
             if self.var.only_radiation:
-                # for pySnowclim
-                eps = 0.621979008
                 # molecular weight of water vapor / The molecular weight of dry air: 18.015 g/mol / 28.964 g/mol
                 self.var.Psurf = Psycon / 0.665E-3
                 self.var.Rsdl = RNup - RLN

--- a/cwatm/hydrological_modules/initcondition.py
+++ b/cwatm/hydrological_modules/initcondition.py
@@ -301,10 +301,11 @@ class initcondition(object):
 
         # list all initiatial variables
         # Snow & Frost
-        number = int(loadmap('NumberSnowLayers'))
-        for i in range(number):
-            initCondVar.append("SnowCover"+str(i+1))
-            initCondVarValue.append("SnowCoverS["+str(i)+"]")
+        if not checkOption('usepySnowClim'):
+            number = int(loadmap('NumberSnowLayers'))
+            for i in range(number):
+                initCondVar.append("SnowCover"+str(i+1))
+                initCondVarValue.append("SnowCoverS["+str(i)+"]")
         initCondVar.append("FrostIndex")
         initCondVarValue.append("FrostIndex")
 

--- a/cwatm/hydrological_modules/readmeteo.py
+++ b/cwatm/hydrological_modules/readmeteo.py
@@ -239,6 +239,7 @@ class readmeteo(object):
         # Check if option pySnowClim exists
         self.var.usepySnowClim = checkOption('usepySnowClim', True)
         if self.var.usepySnowClim:
+            self.var.useTdew = returnBool('useTdew')
             # if pySnowClim is used then all meteo var has to be read anyway
             # and missing meteo variables have to be calculated in evapoPot.py
             self.var.calc_evapo = True
@@ -269,6 +270,9 @@ class readmeteo(object):
             if self.var.pet_modus == 5:
                 # for modified Thornthwaite: uses only tmin, tmax, tavg
                 meteomaps = [self.var.preMaps, self.var.tempMaps, 'TminMaps', 'TmaxMaps']
+
+            if self.var.usepySnowClim and self.var.useTdew:
+                meteomaps.append('TdewMaps')
 
 
             if self.var.includeGlaciers:
@@ -872,7 +876,6 @@ class readmeteo(object):
                 # potential evaporation rate from a bare soil surface (conversion # to [m] per time step)
 
         if self.var.usepySnowClim:
-            self.var.useTdew = returnBool('useTdew')
             if self.var.useTdew:
                 # if tDew maps are available, otherwise use Eact (vapor pressure and calculate Tdew
                 self.var.Tdew = readmeteodata('TdewMaps',

--- a/cwatm/hydrological_modules/readmeteo.py
+++ b/cwatm/hydrological_modules/readmeteo.py
@@ -274,7 +274,6 @@ class readmeteo(object):
             if self.var.usepySnowClim and self.var.useTdew:
                 meteomaps.append('TdewMaps')
 
-
             if self.var.includeGlaciers:
                 meteomaps.append(self.var.glaciermeltMaps)
                 if not self.var.includeOnlyGlaciersMelt:

--- a/cwatm/hydrological_modules/snow_frost.py
+++ b/cwatm/hydrological_modules/snow_frost.py
@@ -395,6 +395,24 @@ class snow_frost(object):
             self.var.snowpack = self.var.Snowpack(globals.inZero.shape[0],
                                          self.var.snowclimParameters)
             self.var.snowModelvars = SnowModelVariables(globals.inZero.shape[0])
+
+
+            self.var.pySnowClimInitVars = ['lastpacktemp', 'snowage', 'lastalbedo', 'lastswe', 'lastsnowdepth', 'packsnowdensity', 'lastpackcc', 'lastpackwater', 'rain_in_snow']
+
+            if returnBool('load_initial_pySnowClim'):
+                loadInitFilepySnowClim = cbinding('initLoad_pySnowClim')
+                #with np.load(loadInitFilepySnowClim) as data:
+                #    for k in self.var.pySnowClimInitVars:
+                #        if k in data.files:
+                #            setattr(self.var.snowpack, k, data[k])
+                for v in self.var.pySnowClimInitVars:
+                    var = readnetcdfInitial(loadInitFilepySnowClim, v)
+                    setattr(self.var.snowpack, v, var)
+
+            self.var.saveInitpySnowClim = returnBool('save_initial_pySnowClim')
+            if self.var.saveInitpySnowClim:
+                self.var.saveInitFilepySnowClim = cbinding('initSave_pySnowClim')
+
     # --------------------------------------------------------------------------
 # --------------------------------------------------------------------------
 
@@ -538,6 +556,18 @@ class snow_frost(object):
             self.var.IceMelt = globals.inZero.copy()
             self.var.iceEvap = globals.inZero.copy()
 
+            # if save initial pySnowClim
+            if self.var.saveInitpySnowClim and self.var.saveInit:
+                if  dateVar['curr'] in dateVar['intInit']:
+                    saveFile = self.var.saveInitFilepySnowClim + "_" + "%02d%02d%02d.npz" % (dateVar['currDate'].year, dateVar['currDate'].month, dateVar['currDate'].day)
+                    initVar = []
+                    #var_dict = {k : v for k, v in vars(self.var.snowpack).items() if k in self.var.pySnowClimInitVars}
+                    #np.savez_compressed(saveFile, **var_dict)
+
+                    for v in self.var.pySnowClimInitVars:
+                        variable = "self.var.snowpack."+v
+                        initVar.append(eval(variable))
+                    writeIniNetcdf(saveFile, self.var.pySnowClimInitVars, initVar)
 
         else:
 

--- a/cwatm/hydrological_modules/snow_frost.py
+++ b/cwatm/hydrological_modules/snow_frost.py
@@ -260,7 +260,6 @@ class snow_frost(object):
             self.var.dem = loadmap('dem')
             self.var.lat = loadmap('latitude')
 
-
         # Pixel-average initial snow cover: average of values in 3 elevation
         # zones
 
@@ -396,7 +395,20 @@ class snow_frost(object):
                                          self.var.snowclimParameters)
             self.var.snowModelvars = SnowModelVariables(globals.inZero.shape[0])
 
-
+            # tarboton albedo alg requires latitude
+            if self.var.albedo_option == 2:
+                try:
+                    self.var.lat = loadmap('latitude')
+                except (CWATMError, CWATMFileError) as e:
+                    rows = maskmapAttr['row']
+                    cell_size = maskmapAttr['cell']
+                    yu = maskmapAttr['y']
+                    yd = yu - rows*cell_size
+                    latitudes = np.linspace(yu, yd, rows, endpoint=False)
+                    latitudes = latitudes - cell_size/2
+                    latitudes_hstack = np.transpose([latitudes]*maskmapAttr['col'])
+                    self.var.lat = compressArray(latitudes_hstack)
+                               
             self.var.pySnowClimInitVars = ['lastpacktemp', 'snowage', 'lastalbedo', 'lastswe', 'lastsnowdepth', 'packsnowdensity', 'lastpackcc', 'lastpackwater', 'rain_in_snow']
 
             if returnBool('load_initial_pySnowClim'):
@@ -493,11 +505,17 @@ class snow_frost(object):
                         "relhum": self.var.rhs,
                         "tdmean": self.var.Tdew
                 }
+            
             # TODO Lat is only used in snowcilm to calculate albedo and define the
             # sizes of the classes. The variable to get lat should be added here after.
             # There is only 1 albedo scheme which uses lat. Tavg is passed here
             # only to have the size of the classes correctly.
-            coords = {"lat": self.var.Tavg}
+            if self.var.albedo_option == 2:
+                coords = {"lat": self.var.lat}
+            else:
+                # lat only required with tarboton albedo
+                coords = {"lat": self.var.Tavg}
+
             forcings_data = {"forcings": forcings, "coords": coords}
 
             # Because CWatM handles data differenty and it is daily these
@@ -528,6 +546,7 @@ class snow_frost(object):
                 coords,
                 time_value,
                 previous_energy)
+            
             snow_vars.CCsnowfall = precip.snowfallcc.copy()
             self.var.snowModelvars =  self.var._prepare_outputs(snow_vars, precip)
 

--- a/cwatm/hydrological_modules/snow_frost.py
+++ b/cwatm/hydrological_modules/snow_frost.py
@@ -401,10 +401,6 @@ class snow_frost(object):
 
             if returnBool('load_initial_pySnowClim'):
                 loadInitFilepySnowClim = cbinding('initLoad_pySnowClim')
-                #with np.load(loadInitFilepySnowClim) as data:
-                #    for k in self.var.pySnowClimInitVars:
-                #        if k in data.files:
-                #            setattr(self.var.snowpack, k, data[k])
                 for v in self.var.pySnowClimInitVars:
                     var = readnetcdfInitial(loadInitFilepySnowClim, v)
                     setattr(self.var.snowpack, v, var)
@@ -559,10 +555,8 @@ class snow_frost(object):
             # if save initial pySnowClim
             if self.var.saveInitpySnowClim and self.var.saveInit:
                 if  dateVar['curr'] in dateVar['intInit']:
-                    saveFile = self.var.saveInitFilepySnowClim + "_" + "%02d%02d%02d.npz" % (dateVar['currDate'].year, dateVar['currDate'].month, dateVar['currDate'].day)
+                    saveFile = self.var.saveInitFilepySnowClim + "_" + "%02d%02d%02d.nc" % (dateVar['currDate'].year, dateVar['currDate'].month, dateVar['currDate'].day)
                     initVar = []
-                    #var_dict = {k : v for k, v in vars(self.var.snowpack).items() if k in self.var.pySnowClimInitVars}
-                    #np.savez_compressed(saveFile, **var_dict)
 
                     for v in self.var.pySnowClimInitVars:
                         variable = "self.var.snowpack."+v

--- a/cwatm/management_modules/data_handling.py
+++ b/cwatm/management_modules/data_handling.py
@@ -1933,7 +1933,10 @@ def readnetcdfInitial(name, value,default = 0.0):
                 raise CWATMFileError(filename, msg)
 
             #mapnp = (nf1.variables[value][:].astype(np.float64))
-            mapnp = nf1.variables[value][cut2:cut3, cut0:cut1].astype(np.float64)
+            #mapnp = nf1.variables[value][cut2:cut3, cut0:cut1].astype(np.float64)
+            var = nf1.variables[value]
+            var.set_auto_maskandscale(False)  # preserve stored dtype
+            mapnp = nf1.variables[value][cut2:cut3, cut0:cut1]
 
             # read creating date
             try:
@@ -2427,17 +2430,19 @@ def writeIniNetcdf(netfile,varlist, inputlist):
 
     i = 0
     for varname in varlist:
+        dtype_str = np.asarray(inputlist[i][0]).dtype.name 
+        type_args = {'float64':'f8', 'float32':'f4'}
         latlon = True
         if 'x' in list(metadataNCDF.keys()):
             latlon = False
-            value = nf1.createVariable(varname, 'f8', ('y', 'x'), zlib=True,fill_value=1e20)
+            value = nf1.createVariable(varname, type_args[dtype_str], ('y', 'x'), zlib=True,fill_value=1e20)
         if 'X' in list(metadataNCDF.keys()):
             latlon = False
-            value = nf1.createVariable(varname, 'f8', ('y', 'x'), zlib=True,fill_value=1e20)
+            value = nf1.createVariable(varname, type_args[dtype_str], ('y', 'x'), zlib=True,fill_value=1e20)
         if latlon:
             if 'lon' in list(metadataNCDF.keys()):
                 # for world lat/lon coordinates
-                value = nf1.createVariable(varname, 'f8', ('lat', 'lon'), zlib=True, fill_value=1e20)
+                value = nf1.createVariable(varname, type_args[dtype_str], ('lat', 'lon'), zlib=True, fill_value=1e20)
 
         value.standard_name= getmeta("standard_name",varname,varname)
         value.long_name= getmeta("long_name",varname,varname)


### PR DESCRIPTION
This branch has three commits which:
- Fix some small bugs with CWatM-pySnowClim
   - change in evaporationpot.py ensures that eps variable is always defined
   - change in initcondition.py removes snow cover layers from initial conditions if pySnowClim is used, preventing potential errors caused by saving default snowCover values
   - changes in readmeteo.py append the Tdew map to meteomaps so that it can be read with readmeteodata
   - *I did not change the pySnowClim read me to include a more accurate config file, but I think this might be helpful for users
- Add the feature to save and load pySnowClim initial conditions in their own netCDF file
   - changes in data_handling.py stop the 32bit float variables from pySnowClim being cast as 64bit floats during save and load, which causes some precision errors.
- Pass latitude to the Tarboton albedo algorithm in pySnowClim